### PR TITLE
Install and Configure dnsmasq and DHCP

### DIFF
--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart dnsmasq
+  service: name=dnsmasq.service state=restarted
+
+- name: restart networkmanager
+  service: name=NetworkManager state=restarted

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: install dnsmasq
+  package: name=dnsmasq state=present
+  become: true
+
+- name: configure
+  template: src=dnsmasq.conf.j2 dest=/etc/dnsmasq.conf owner=root group=root mode=0644
+  notify: restart dnsmasq
+  become: true
+
+- name: configure dhclient
+  template: src=dhclient.conf.j2 dest=/etc/dhclient.conf owner=root group=root mode=0644
+  notify: restart networkmanager
+  become: true
+
+- name: start dnsmasq
+  systemd: name=dnsmasq.service enabled=true state=started
+  become: true

--- a/roles/dnsmasq/templates/dhclient.conf.j2
+++ b/roles/dnsmasq/templates/dhclient.conf.j2
@@ -1,0 +1,1 @@
+prepend domain-name-servers 127.0.0.1;

--- a/roles/dnsmasq/templates/dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/dnsmasq.conf.j2
@@ -1,0 +1,2 @@
+# ask the local consul agent for consul addresses
+server=/consul/127.0.0.1#8600

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -6,6 +6,7 @@
     - role: vagrant-rust-dev
     - role: consul-server
     - role: openresty
+    - role: dnsmasq
   tasks:
     - name: be an adult
       selinux: state=enforcing policy=targeted


### PR DESCRIPTION
Prepend 127.0.0.1 (dnsmasq) as the primary resolver and the one responsible for Consul domain name resolution.